### PR TITLE
healer: fix issue #6 - CI fails because ModelConfigTests still expect /v1 Ollama base URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to apple-code are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Ollama URL contract tests** — `ModelConfigTests` now assert native Ollama base URLs without an implicit `/v1` suffix, matching the runtime's `/api/chat` and `/api/tags` requests.
+
 ## [v0.2.0] — 2026-03-04
 
 ### Added

--- a/Sources/AppleCode/ModelClient.swift
+++ b/Sources/AppleCode/ModelClient.swift
@@ -77,7 +77,7 @@ func makeModelClient(
 
         let rawBaseURL: String = config.baseURL
             ?? env["OLLAMA_BASE_URL"]
-            ?? "http://127.0.0.1:11434"
+            ?? ModelConfig.defaultOllamaBaseURL
         guard let baseURL = URL(string: rawBaseURL) else {
             throw ModelClientFactoryError.invalidBaseURL
         }
@@ -356,7 +356,7 @@ private struct OllamaModelClient: ModelClient {
     }
 
     private func chatURL() -> URL {
-        baseURL.appendingPathComponent("api").appendingPathComponent("chat")
+        baseURL.appendingOllamaEndpoint("chat")
     }
 }
 

--- a/Sources/AppleCode/ModelConfig.swift
+++ b/Sources/AppleCode/ModelConfig.swift
@@ -34,6 +34,7 @@ struct ModelConfig: Codable, Sendable {
     let baseURL: String?
 
     static let appleDefault = ModelConfig(provider: .apple, model: nil, baseURL: nil)
+    static let defaultOllamaBaseURL = "http://127.0.0.1:11434"
 
     var modeLabel: String {
         switch provider {
@@ -78,7 +79,7 @@ struct ModelConfig: Codable, Sendable {
 
             let rawBaseURL = nonEmpty(trimmedBaseURL)
                 ?? nonEmpty(env["OLLAMA_BASE_URL"])
-                ?? "http://127.0.0.1:11434"
+                ?? defaultOllamaBaseURL
             let normalizedBaseURL = try normalizeBaseURL(rawBaseURL)
 
             return ModelConfig(
@@ -114,6 +115,12 @@ struct ModelConfig: Codable, Sendable {
             throw ModelConfigError.invalidBaseURL(raw)
         }
         return url
+    }
+}
+
+extension URL {
+    func appendingOllamaEndpoint(_ endpoint: String) -> URL {
+        appendingPathComponent("api").appendingPathComponent(endpoint)
     }
 }
 

--- a/Sources/AppleCode/OllamaModelDiscovery.swift
+++ b/Sources/AppleCode/OllamaModelDiscovery.swift
@@ -73,7 +73,7 @@ enum OllamaModelDiscovery {
     }
 
     private static func installedModelsFromAPI(baseURL: URL) async -> [String] {
-        let tagsURL = baseURL.appendingPathComponent("api").appendingPathComponent("tags")
+        let tagsURL = baseURL.appendingOllamaEndpoint("tags")
         var request = URLRequest(url: tagsURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 8

--- a/Tests/AppleCodeTests/ModelConfigTests.swift
+++ b/Tests/AppleCodeTests/ModelConfigTests.swift
@@ -25,7 +25,7 @@ final class ModelConfigTests: XCTestCase {
 
         XCTAssertEqual(config.provider, .ollama)
         XCTAssertEqual(config.model, "qwen3.5:4b")
-        XCTAssertEqual(config.baseURL, "http://127.0.0.1:11434/v1")
+        XCTAssertEqual(config.baseURL, ModelConfig.defaultOllamaBaseURL)
     }
 
     func testResolveReadsEnvironmentForOllama() throws {
@@ -41,7 +41,7 @@ final class ModelConfigTests: XCTestCase {
 
         XCTAssertEqual(config.provider, .ollama)
         XCTAssertEqual(config.model, "qwen2.5-coder:7b")
-        XCTAssertEqual(config.baseURL, "http://localhost:11435/v1")
+        XCTAssertEqual(config.baseURL, "http://localhost:11435")
     }
 
     func testResolveRejectsRemoteFlagsForApple() {
@@ -60,9 +60,9 @@ final class ModelConfigTests: XCTestCase {
         }
     }
 
-    func testNormalizeBaseURLAddsV1Path() throws {
+    func testNormalizeBaseURLPreservesNativeOllamaBasePath() throws {
         let url = try ModelConfig.normalizeBaseURL("http://127.0.0.1:11434")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11434/v1")
+        XCTAssertEqual(url.absoluteString, ModelConfig.defaultOllamaBaseURL)
     }
 
     func testNormalizeBaseURLRejectsInvalidScheme() {


### PR DESCRIPTION
Automated healer proposal for issue #6.

- Verifier: passed
- Targeted/full test gates: {'mode': 'local_only', 'failed_tests': 0, 'targeted_tests': [], 'language_detected': 'swift', 'language_effective': 'swift', 'docker_image_effective': '', 'execution_root': '', 'execution_root_source': 'repo', 'local_gate_policy': 'force', 'local_full_exit_code': 0, 'local_full_output_tail': "9.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'apple-codePackageTests.xctest' passed at 2026-03-07 00:34:27.419.\n\t Executed 87 tests, with 0 failures (0 unexpected) in 3.074 (3.084) seconds\nTest Suite 'All tests' passed at 2026-03-07 00:34:27.419.\n\t Executed 87 tests, with 0 failures (0 unexpected) in 3.074 (3.086) seconds\n\x1b[1mAvailable Commands:\x1b[0m\n\n\x1b[36m/new\x1b[0m (or /n)     Start a new session\n\x1b[36m/sessions\x1b[0m (or /s)  List all saved sessions\n\x1b[36m/resume <id>\x1b[0m      Resume a session by ID\n\x1b[36m/delete <id>\x1b[0m      Delete a session\n\x1b[36m/history [n]\x1b[0m      Show recent transcript entries\n\x1b[36m/show <id>\x1b[0m        Show full entry by transcript ID\n\x1b[36m/model\x1b[0m (or /m)     Show current model info\n\x1b[36m/settings\x1b[0m          Open settings menu (provider/model/ui/theme/session)\n\x1b[36m/ui [classic|framed]\x1b[0m  Switch REPL renderer mode\n\x1b[36m/session <id|next|prev>\x1b[0m Quick switch session\n\x1b[36m/cd <path>\x1b[0m        Change working directory\n\x1b[36m/clear\x1b[0m (or /c)    Clear the screen\n\x1b[36m/theme <name>\x1b[0m     Switch theme (wow, minimal, classic, solar, ocean, forest)\n\x1b[36m/compact\x1b[0m            Summarize old turns to free context window\n\x1b[36m/help\x1b[0m (or /h)    Show this help\n\x1b[36m/quit\x1b[0m (or /q)     Exit apple-code\n\n\x1b[90mCompatibility: :commands still work.\x1b[0m\n\n\x1b[90mKeys: Enter submit, Ctrl+J newline, arrows navigate history/edit.\x1b[0m\n\x1b[90mKeys: Ctrl+P settings • Esc(Ctrl+[) prev session • Ctrl+] next session.\x1b[0m\n\x1b[90mProvider: apple (AFM) or ollama (local) via /settings.\x1b[0m\n\x1b[90mTip: Just type a message to chat. The AI will use tools when needed.\x1b[0m\nResumed session 024FEAD0\nWorking directory: /tmp\nMessages: 1\n\nDeleted session 024FEAD0\n◇ Test run started.\n↳ Testing Library Version: 1501\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n\n[0/1] Planning build\nBuilding for debugging...\n[0/4] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.25s)", 'local_full_status': 'passed', 'workspace_status': {'execution_root': '', 'staged_paths': ['CHANGELOG.md', 'Sources/AppleCode/ModelClient.swift', 'Sources/AppleCode/ModelConfig.swift', 'Sources/AppleCode/OllamaModelDiscovery.swift', 'Tests/AppleCodeTests/ModelConfigTests.swift'], 'unstaged_paths': [], 'untracked_paths': [], 'contamination_paths': [], 'cleanup_performed': False, 'cleaned_paths': [], 'cleanup_cycles_used': 0}}
