### PR TITLE
healer: fix issue #7 - Reject or sanitize Ollama base URLs that already contain a path

### DIFF
--- a/Sources/AppleCode/ModelClient.swift
+++ b/Sources/AppleCode/ModelClient.swift
@@ -78,8 +78,11 @@ func makeModelClient(
         let rawBaseURL: String = config.baseURL
             ?? env["OLLAMA_BASE_URL"]
             ?? "http://127.0.0.1:11434"
-        guard let baseURL = URL(string: rawBaseURL) else {
-            throw ModelClientFactoryError.invalidBaseURL
+        let baseURL: URL
+        do {
+            baseURL = try ModelConfig.normalizeBaseURL(rawBaseURL)
+        } catch {
+            throw ModelClientFactoryError.invalidBaseURL(rawBaseURL)
         }
         return OllamaModelClient(config: config, model: model, baseURL: baseURL)
     }
@@ -88,7 +91,7 @@ func makeModelClient(
 enum ModelClientFactoryError: LocalizedError {
     case appleUnavailable
     case missingModel
-    case invalidBaseURL
+    case invalidBaseURL(String)
     case modelNotInstalled(model: String)
     case ollamaUnavailable(String)
 
@@ -98,8 +101,8 @@ enum ModelClientFactoryError: LocalizedError {
             return "Apple Foundation Models not available. Requires macOS 26+ on Apple Silicon."
         case .missingModel:
             return "Ollama requires a model. Select one in /settings or set --model / OLLAMA_MODEL."
-        case .invalidBaseURL:
-            return "Ollama base URL is invalid."
+        case .invalidBaseURL(let value):
+            return "Invalid Ollama base URL '\(value)'. Use the server root only, for example http://127.0.0.1:11434."
         case .modelNotInstalled(let model):
             return "Model '\(model)' is not installed locally. Run: ollama pull \(model)"
         case .ollamaUnavailable(let detail):

--- a/Sources/AppleCode/ModelConfig.swift
+++ b/Sources/AppleCode/ModelConfig.swift
@@ -97,7 +97,8 @@ struct ModelConfig: Codable, Sendable {
     }
 
     static func normalizeBaseURL(_ raw: String) throws -> URL {
-        guard var components = URLComponents(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
               let scheme = components.scheme?.lowercased(),
               (scheme == "http" || scheme == "https") else {
             throw ModelConfigError.invalidBaseURL(raw)
@@ -105,10 +106,9 @@ struct ModelConfig: Codable, Sendable {
 
         let cleanedPath = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         if !cleanedPath.isEmpty {
-            components.path = "/" + cleanedPath
-        } else {
-            components.path = ""
+            throw ModelConfigError.invalidBaseURL(raw)
         }
+        components.path = ""
 
         guard let url = components.url else {
             throw ModelConfigError.invalidBaseURL(raw)
@@ -131,7 +131,7 @@ enum ModelConfigError: LocalizedError {
             }
             return "Invalid provider '\(value)'. Use 'apple' or 'ollama'."
         case .invalidBaseURL(let value):
-            return "Invalid base URL '\(value)'. Use a valid http or https URL."
+            return "Invalid base URL '\(value)'. Use the Ollama server root only, for example http://127.0.0.1:11434."
         case .missingModel:
             return "Ollama provider requires a model. Set --model or OLLAMA_MODEL."
         case .appleDoesNotUseRemoteModelFlags:

--- a/Sources/AppleCode/OllamaModelDiscovery.swift
+++ b/Sources/AppleCode/OllamaModelDiscovery.swift
@@ -73,7 +73,13 @@ enum OllamaModelDiscovery {
     }
 
     private static func installedModelsFromAPI(baseURL: URL) async -> [String] {
-        let tagsURL = baseURL.appendingPathComponent("api").appendingPathComponent("tags")
+        guard let normalizedBaseURL = try? ModelConfig.normalizeBaseURL(baseURL.absoluteString) else {
+            return []
+        }
+
+        let tagsURL = normalizedBaseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("tags")
         var request = URLRequest(url: tagsURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 8

--- a/Tests/AppleCodeTests/ModelConfigTests.swift
+++ b/Tests/AppleCodeTests/ModelConfigTests.swift
@@ -25,7 +25,7 @@ final class ModelConfigTests: XCTestCase {
 
         XCTAssertEqual(config.provider, .ollama)
         XCTAssertEqual(config.model, "qwen3.5:4b")
-        XCTAssertEqual(config.baseURL, "http://127.0.0.1:11434/v1")
+        XCTAssertEqual(config.baseURL, "http://127.0.0.1:11434")
     }
 
     func testResolveReadsEnvironmentForOllama() throws {
@@ -41,7 +41,7 @@ final class ModelConfigTests: XCTestCase {
 
         XCTAssertEqual(config.provider, .ollama)
         XCTAssertEqual(config.model, "qwen2.5-coder:7b")
-        XCTAssertEqual(config.baseURL, "http://localhost:11435/v1")
+        XCTAssertEqual(config.baseURL, "http://localhost:11435")
     }
 
     func testResolveRejectsRemoteFlagsForApple() {
@@ -60,9 +60,34 @@ final class ModelConfigTests: XCTestCase {
         }
     }
 
-    func testNormalizeBaseURLAddsV1Path() throws {
+    func testNormalizeBaseURLPreservesHostRoot() throws {
         let url = try ModelConfig.normalizeBaseURL("http://127.0.0.1:11434")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11434/v1")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11434")
+    }
+
+    func testNormalizeBaseURLRemovesTrailingSlash() throws {
+        let url = try ModelConfig.normalizeBaseURL("http://127.0.0.1:11434/")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11434")
+    }
+
+    func testNormalizeBaseURLRejectsAPIRootPath() {
+        XCTAssertThrowsError(try ModelConfig.normalizeBaseURL("http://localhost:11434/api")) { error in
+            guard case ModelConfigError.invalidBaseURL(let value) = error else {
+                XCTFail("Expected invalidBaseURL, got: \(error)")
+                return
+            }
+            XCTAssertEqual(value, "http://localhost:11434/api")
+        }
+    }
+
+    func testNormalizeBaseURLRejectsV1Path() {
+        XCTAssertThrowsError(try ModelConfig.normalizeBaseURL("http://localhost:11434/v1/")) { error in
+            guard case ModelConfigError.invalidBaseURL(let value) = error else {
+                XCTFail("Expected invalidBaseURL, got: \(error)")
+                return
+            }
+            XCTAssertEqual(value, "http://localhost:11434/v1/")
+        }
     }
 
     func testNormalizeBaseURLRejectsInvalidScheme() {
@@ -98,6 +123,9 @@ final class ModelConfigTests: XCTestCase {
         )
         XCTAssertTrue(
             ModelConfigError.missingModel.localizedDescription.contains("requires a model")
+        )
+        XCTAssertTrue(
+            ModelConfigError.invalidBaseURL("http://localhost:11434/api").localizedDescription.contains("server root only")
         )
     }
 }


### PR DESCRIPTION
Automated Flow Healer proposal for issue #7.

### Verification
- Verifier: `The patch is appropriately scoped and satisfies the issue contract. It chooses the reject-path-bearing-URLs contract, enforces it in `ModelConfig.normalizeBaseURL`, adds explicit user-facing error text describing the supported Ollama base URL shape, and app...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `swift`
- Local full gate: `passed`
