### PR TITLE
healer: fix issue #4 - Reject --provider ollama without a model during config resolution

### DIFF
--- a/Sources/AppleCode/ModelClient.swift
+++ b/Sources/AppleCode/ModelClient.swift
@@ -72,7 +72,7 @@ func makeModelClient(
 
     case .ollama:
         guard let model = config.model?.trimmingCharacters(in: .whitespacesAndNewlines), !model.isEmpty else {
-            throw ModelClientFactoryError.missingModel
+            throw ModelConfigError.missingModel
         }
 
         let rawBaseURL: String = config.baseURL
@@ -87,7 +87,6 @@ func makeModelClient(
 
 enum ModelClientFactoryError: LocalizedError {
     case appleUnavailable
-    case missingModel
     case invalidBaseURL
     case modelNotInstalled(model: String)
     case ollamaUnavailable(String)
@@ -96,8 +95,6 @@ enum ModelClientFactoryError: LocalizedError {
         switch self {
         case .appleUnavailable:
             return "Apple Foundation Models not available. Requires macOS 26+ on Apple Silicon."
-        case .missingModel:
-            return "Ollama requires a model. Select one in /settings or set --model / OLLAMA_MODEL."
         case .invalidBaseURL:
             return "Ollama base URL is invalid."
         case .modelNotInstalled(let model):

--- a/Sources/AppleCode/ModelConfig.swift
+++ b/Sources/AppleCode/ModelConfig.swift
@@ -75,6 +75,9 @@ struct ModelConfig: Codable, Sendable {
 
         case .ollama:
             let effectiveModel = nonEmpty(trimmedModel) ?? nonEmpty(env["OLLAMA_MODEL"])
+            guard effectiveModel != nil else {
+                throw ModelConfigError.missingModel
+            }
 
             let rawBaseURL = nonEmpty(trimmedBaseURL)
                 ?? nonEmpty(env["OLLAMA_BASE_URL"])


### PR DESCRIPTION
Automated Flow Healer proposal for issue #4.

### Verification
- Verifier: `The staged patch is appropriately scoped to Sources/AppleCode/ModelConfig.swift and Sources/AppleCode/ModelClient.swift and fixes the issue described. ModelConfig.resolve(...) now fails fast for provider ollama when neither --model nor OLLAMA_MODEL is prese...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `skipped_artifact_only`
- Language: `swift`
