### PR TITLE
healer: fix issue #2 - Fix /cd accepting file paths and desyncing session working directory

### DIFF
--- a/Sources/AppleCode/REPLLoop.swift
+++ b/Sources/AppleCode/REPLLoop.swift
@@ -92,6 +92,38 @@ private actor StreamEventBuffer {
     }
 }
 
+enum ChangeDirectoryResult: Equatable {
+    case success(String)
+    case missing(String)
+    case notDirectory(String)
+    case failed(String)
+}
+
+@discardableResult
+func changeWorkingDirectory(
+    to path: String,
+    session: inout Session,
+    fileManager: FileManager = .default
+) -> ChangeDirectoryResult {
+    let expandedPath = (path as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+
+    guard fileManager.fileExists(atPath: expandedPath, isDirectory: &isDirectory) else {
+        return .missing(expandedPath)
+    }
+
+    guard isDirectory.boolValue else {
+        return .notDirectory(expandedPath)
+    }
+
+    guard fileManager.changeCurrentDirectoryPath(expandedPath) else {
+        return .failed(expandedPath)
+    }
+
+    session.workingDir = expandedPath
+    return .success(expandedPath)
+}
+
 func runInteractiveREPL(
     session: inout Session,
     initialModelConfig: ModelConfig,
@@ -702,10 +734,8 @@ func runInteractiveREPL(
             continue
 
         case .changeDirectory(let path):
-            let expandedPath = (path as NSString).expandingTildeInPath
-            if FileManager.default.fileExists(atPath: expandedPath) {
-                FileManager.default.changeCurrentDirectoryPath(expandedPath)
-                session.workingDir = expandedPath
+            switch changeWorkingDirectory(to: path, session: &session) {
+            case .success(let expandedPath):
                 if useAdvancedUI, let renderer, var state = uiState, let viewport {
                     viewport.append(role: "system", content: "Changed directory to: \(expandedPath)")
                     renderAdvancedShell(
@@ -719,7 +749,7 @@ func runInteractiveREPL(
                 } else {
                     printSuccess("Changed directory to: \(expandedPath)")
                 }
-            } else {
+            case .missing(let expandedPath):
                 if useAdvancedUI, let renderer, var state = uiState, let viewport {
                     viewport.append(role: "error", content: "Directory not found: \(expandedPath)")
                     renderAdvancedShell(
@@ -732,6 +762,34 @@ func runInteractiveREPL(
                     uiState = state
                 } else {
                     printError("Directory not found: \(expandedPath)")
+                }
+            case .notDirectory(let expandedPath):
+                if useAdvancedUI, let renderer, var state = uiState, let viewport {
+                    viewport.append(role: "error", content: "Not a directory: \(expandedPath)")
+                    renderAdvancedShell(
+                        renderer: renderer,
+                        state: &state,
+                        viewport: viewport,
+                        cwd: session.workingDir,
+                        mode: activeModelConfig.modeLabel
+                    )
+                    uiState = state
+                } else {
+                    printError("Not a directory: \(expandedPath)")
+                }
+            case .failed(let expandedPath):
+                if useAdvancedUI, let renderer, var state = uiState, let viewport {
+                    viewport.append(role: "error", content: "Failed to change directory: \(expandedPath)")
+                    renderAdvancedShell(
+                        renderer: renderer,
+                        state: &state,
+                        viewport: viewport,
+                        cwd: session.workingDir,
+                        mode: activeModelConfig.modeLabel
+                    )
+                    uiState = state
+                } else {
+                    printError("Failed to change directory: \(expandedPath)")
                 }
             }
             continue

--- a/Tests/AppleCodeTests/CLICommandsBehaviorTests.swift
+++ b/Tests/AppleCodeTests/CLICommandsBehaviorTests.swift
@@ -3,6 +3,20 @@ import XCTest
 
 @MainActor
 final class CLICommandsBehaviorTests: XCTestCase {
+    private func withPreservedWorkingDirectory(
+        _ body: (String) throws -> Void
+    ) rethrows {
+        let originalWorkingDirectory = FileManager.default.currentDirectoryPath
+        defer {
+            _ = FileManager.default.changeCurrentDirectoryPath(originalWorkingDirectory)
+        }
+        try body(originalWorkingDirectory)
+    }
+
+    private func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
     func testParseAdditionalAliasesAndArguments() {
         guard case .listSessions = parseCommand("/list-sessions") else {
             return XCTFail("Expected listSessions")
@@ -38,5 +52,64 @@ final class CLICommandsBehaviorTests: XCTestCase {
 
         await handleDeleteSession(id: session.id)
         XCTAssertFalse(manager.listSessions().contains(where: { $0.id == session.id }))
+    }
+
+    func testChangeWorkingDirectoryUpdatesSessionOnlyOnValidDirectory() throws {
+        try withPreservedWorkingDirectory { originalWorkingDirectory in
+            let tempRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let targetDirectory = tempRoot.appendingPathComponent("subdir", isDirectory: true)
+            try FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+
+            var session = Session(workingDir: originalWorkingDirectory)
+            let targetPath = standardizedPath(targetDirectory.path)
+
+            let result = changeWorkingDirectory(to: targetDirectory.path, session: &session)
+
+            XCTAssertEqual(result, .success(targetPath))
+            XCTAssertEqual(standardizedPath(session.workingDir), targetPath)
+            XCTAssertEqual(standardizedPath(FileManager.default.currentDirectoryPath), targetPath)
+        }
+    }
+
+    func testChangeWorkingDirectoryRejectsMissingPath() {
+        withPreservedWorkingDirectory { originalWorkingDirectory in
+            let missingPath = standardizedPath(
+                FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString, isDirectory: true).path
+            )
+            var session = Session(workingDir: originalWorkingDirectory)
+
+            let result = changeWorkingDirectory(to: missingPath, session: &session)
+
+            XCTAssertEqual(result, .missing(missingPath))
+            XCTAssertEqual(standardizedPath(session.workingDir), standardizedPath(originalWorkingDirectory))
+            XCTAssertEqual(
+                standardizedPath(FileManager.default.currentDirectoryPath),
+                standardizedPath(originalWorkingDirectory)
+            )
+        }
+    }
+
+    func testChangeWorkingDirectoryRejectsFilePath() throws {
+        try withPreservedWorkingDirectory { originalWorkingDirectory in
+            let tempRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+            let fileURL = tempRoot.appendingPathComponent("note.txt", isDirectory: false)
+            try Data("hello".utf8).write(to: fileURL)
+
+            var session = Session(workingDir: originalWorkingDirectory)
+            let filePath = standardizedPath(fileURL.path)
+
+            let result = changeWorkingDirectory(to: fileURL.path, session: &session)
+
+            XCTAssertEqual(result, .notDirectory(filePath))
+            XCTAssertEqual(standardizedPath(session.workingDir), standardizedPath(originalWorkingDirectory))
+            XCTAssertEqual(
+                standardizedPath(FileManager.default.currentDirectoryPath),
+                standardizedPath(originalWorkingDirectory)
+            )
+        }
     }
 }


### PR DESCRIPTION
Automated Flow Healer proposal for issue #2.

### Verification
- Verifier: `Scoped patch satisfies the issue: `/cd` now rejects missing paths and file paths, checks `changeCurrentDirectoryPath(...)`, and only updates `session.workingDir` after a successful directory change. Regression tests were added for valid directory, missing p...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `skipped_artifact_only`
- Language: `swift`
