### PR TITLE
healer: fix issue #17 - Fix startup --cwd handling to validate directory change success before updating 

### DIFF
--- a/Sources/AppleCode/main.swift
+++ b/Sources/AppleCode/main.swift
@@ -228,6 +228,44 @@ private func effectiveResponseTimeout(for config: ModelConfig, requestedSeconds:
     }
 }
 
+private enum StartupWorkingDirectoryError: LocalizedError {
+    case notFound(String)
+    case notDirectory(String)
+    case changeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound(let path):
+            return "Working directory not found: \(path)"
+        case .notDirectory(let path):
+            return "Working directory is not a directory: \(path)"
+        case .changeFailed(let path):
+            return "Could not change working directory to: \(path)"
+        }
+    }
+}
+
+func prepareStartupWorkingDirectory(cwd: String?) throws -> String {
+    let fileManager = FileManager.default
+    guard let cwd else {
+        return fileManager.currentDirectoryPath
+    }
+
+    let expandedPath = (cwd as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: expandedPath, isDirectory: &isDirectory) else {
+        throw StartupWorkingDirectoryError.notFound(expandedPath)
+    }
+    guard isDirectory.boolValue else {
+        throw StartupWorkingDirectoryError.notDirectory(expandedPath)
+    }
+    guard fileManager.changeCurrentDirectoryPath(expandedPath) else {
+        throw StartupWorkingDirectoryError.changeFailed(expandedPath)
+    }
+
+    return fileManager.currentDirectoryPath
+}
+
 var promptParts: [String] = []
 var systemInstructions: String?
 var cwd: String?
@@ -356,9 +394,16 @@ if checkAppleTools {
     exit(0)
 }
 
+let workingDir: String
+do {
+    workingDir = try prepareStartupWorkingDirectory(cwd: cwd)
+} catch {
+    FileHandle.standardError.write(Data("Error: \(error.localizedDescription)\n".utf8))
+    exit(1)
+}
+
 // Load config file; CLI flags take precedence over config values.
-let effectiveCWD = cwd ?? FileManager.default.currentDirectoryPath
-let fileConfig = AppConfig.load(workingDir: effectiveCWD)
+let fileConfig = AppConfig.load(workingDir: workingDir)
 AppConfig.ensureConfigDir()
 if providerFlag == nil    { providerFlag    = fileConfig.provider }
 if modelFlag == nil       { modelFlag       = fileConfig.model }
@@ -376,14 +421,6 @@ do {
 } catch {
     FileHandle.standardError.write(Data("Error: \(error.localizedDescription)\n".utf8))
     exit(1)
-}
-
-let workingDir: String
-if let cwd = cwd {
-    FileManager.default.changeCurrentDirectoryPath(cwd)
-    workingDir = cwd
-} else {
-    workingDir = FileManager.default.currentDirectoryPath
 }
 
 let shouldBeInteractive = forceInteractive || promptArg == nil || promptArg?.isEmpty == true

--- a/Tests/AppleCodeTests/StartupWorkingDirectoryTests.swift
+++ b/Tests/AppleCodeTests/StartupWorkingDirectoryTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Foundation
+@testable import apple_code
+
+final class StartupWorkingDirectoryTests: XCTestCase {
+    private func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    private func tempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("apple-code-startup-cwd-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func testPrepareStartupWorkingDirectoryChangesIntoValidDirectory() throws {
+        let originalDirectory = FileManager.default.currentDirectoryPath
+        defer { FileManager.default.changeCurrentDirectoryPath(originalDirectory) }
+
+        let directory = try tempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let resolvedDirectory = try prepareStartupWorkingDirectory(cwd: directory.path)
+
+        XCTAssertEqual(normalizedPath(resolvedDirectory), normalizedPath(directory.path))
+        XCTAssertEqual(normalizedPath(FileManager.default.currentDirectoryPath), normalizedPath(directory.path))
+    }
+
+    func testPrepareStartupWorkingDirectoryFailsForMissingPath() throws {
+        let originalDirectory = FileManager.default.currentDirectoryPath
+        defer { FileManager.default.changeCurrentDirectoryPath(originalDirectory) }
+
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("apple-code-missing-\(UUID().uuidString)", isDirectory: true)
+            .path
+
+        XCTAssertThrowsError(try prepareStartupWorkingDirectory(cwd: missingPath)) { error in
+            XCTAssertEqual(error.localizedDescription, "Working directory not found: \(missingPath)")
+        }
+        XCTAssertEqual(FileManager.default.currentDirectoryPath, originalDirectory)
+    }
+
+    func testPrepareStartupWorkingDirectoryFailsForFilePath() throws {
+        let originalDirectory = FileManager.default.currentDirectoryPath
+        defer { FileManager.default.changeCurrentDirectoryPath(originalDirectory) }
+
+        let directory = try tempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let file = directory.appendingPathComponent("not-a-directory.txt")
+        try "content".write(to: file, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try prepareStartupWorkingDirectory(cwd: file.path)) { error in
+            XCTAssertEqual(error.localizedDescription, "Working directory is not a directory: \(file.path)")
+        }
+        XCTAssertEqual(FileManager.default.currentDirectoryPath, originalDirectory)
+    }
+}


### PR DESCRIPTION
Automated Flow Healer proposal for issue #17.

### Verification
- Verifier: `Patch is appropriately scoped and satisfies the issue. `Sources/AppleCode/main.swift` now validates `--cwd` by checking existence, directory type, and `changeCurrentDirectoryPath(...)` success before updating runtime `workingDir`, and it fails fast with cle...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `swift`
- Local full gate: `passed`
