### PR TITLE
healer: fix issue #15 - Do not auto-enable WebFetch just because a URL appears in prompt text

### DIFF
--- a/Sources/AppleCode/main.swift
+++ b/Sources/AppleCode/main.swift
@@ -18,6 +18,7 @@ func printUsage() {
       --no-apple-tools       Disable Apple app tools (Notes, Mail, etc.)
       --check-apple-tools    Run Apple app diagnostics and exit
       --no-web-tools         Disable dedicated web search/fetch tools
+                             URL text alone does not enable page retrieval
       --no-browser-tools     Disable browser automation tools
       --run-web-fetch <url>  Run webFetch tool directly and exit
       --run-web-search "q"   Run webSearch tool directly and exit
@@ -180,10 +181,6 @@ func routeTools(
         p.contains("export") || p.contains("save as") || p.contains("write")
     )
 
-    let hasURLInPrompt = p.contains("http://")
-        || p.contains("https://")
-        || p.contains("littlehakr.substack.com")
-
     let wantsWebSearch = includeWebTools && (!hasNotesIntent || hasExplicitWebIntent) && (
         p.contains("search web") || p.contains("search online") || p.contains("web search") ||
         p.contains("latest") || p.contains("news about") || p.contains("look up online") ||
@@ -192,7 +189,7 @@ func routeTools(
 
     let wantsWebFetch = includeWebTools && (
         p.contains("fetch url") || p.contains("open this url") || p.contains("summarize this page") ||
-        p.contains("extract from") || hasURLInPrompt
+        p.contains("extract from")
     )
 
     if wantsFile   { selected.append(ReadFileTool()); selected.append(WriteFileTool()); selected.append(EditFileTool()) }

--- a/Tests/AppleCodeTests/NewFeaturesTests.swift
+++ b/Tests/AppleCodeTests/NewFeaturesTests.swift
@@ -377,3 +377,29 @@ final class ProjectContextFileTests: XCTestCase {
         XCTAssertTrue(result!.contains("truncated"))
     }
 }
+
+// MARK: - routeTools WebFetch Tests
+
+final class RouteToolsWebFetchTests: XCTestCase {
+    func testPastedURLDoesNotEnableWebFetch() {
+        let tools = routeTools(
+            for: "Here is the link I am referencing: https://example.com/docs",
+            includeAppleTools: true,
+            includeWebTools: true,
+            includeBrowserTools: true
+        )
+
+        XCTAssertFalse(tools.contains { $0.name == "webFetch" })
+    }
+
+    func testExplicitPageFetchRequestEnablesWebFetch() {
+        let tools = routeTools(
+            for: "Please summarize this page: https://example.com/docs",
+            includeAppleTools: true,
+            includeWebTools: true,
+            includeBrowserTools: true
+        )
+
+        XCTAssertTrue(tools.contains { $0.name == "webFetch" })
+    }
+}


### PR DESCRIPTION
Automated Flow Healer proposal for issue #15.

### Verification
- Verifier: `Scoped patch is aligned with Issue #15. In `Sources/AppleCode/main.swift`, `routeTools(...)` no longer enables `webFetch` from URL presence alone and now requires explicit fetch-style phrasing; help text was also updated to reflect the stricter behavior. In...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `swift`
- Local full gate: `passed`
