### PR TITLE
healer: fix issue #12 - Do not auto-enable mutating file tools for read-only file intents

### DIFF
--- a/Sources/AppleCode/main.swift
+++ b/Sources/AppleCode/main.swift
@@ -142,11 +142,17 @@ func routeTools(
         p.contains("repo status")
     )
 
+    let wantsMutatingFile = !hasNotesIntent && !wantsGit && (
+        p.contains("write to") || p.contains("create a file") || p.contains("save to") ||
+        p.contains("edit ") || p.contains("modify ") || p.contains("update ") ||
+        p.contains("append to") || p.contains("replace in")
+    )
+
     let wantsFile = !hasNotesIntent && !wantsGit && (
         p.contains("file") || p.contains("readme") || p.contains("package.swift") ||
         p.contains("read the") || p.contains("read this") || p.contains("show me the") ||
-        p.contains("open ") || p.contains("contents of") || p.contains("write to") ||
-        p.contains("create a file") || p.contains("save to") || p.contains("edit "))
+        p.contains("open ") || p.contains("contents of") || wantsMutatingFile
+    )
 
     let wantsDir = !hasNotesIntent && (p.contains("directory") || p.contains("folder") || p.contains("list files") ||
                    p.contains("what files") || p.contains("what's in") || p.contains("ls ") ||
@@ -195,7 +201,11 @@ func routeTools(
         p.contains("extract from") || hasURLInPrompt
     )
 
-    if wantsFile   { selected.append(ReadFileTool()); selected.append(WriteFileTool()); selected.append(EditFileTool()) }
+    if wantsFile   { selected.append(ReadFileTool()) }
+    if wantsMutatingFile {
+        selected.append(WriteFileTool())
+        selected.append(EditFileTool())
+    }
     if wantsDir    { selected.append(ListDirectoryTool()) }
     if wantsSearch { selected.append(SearchFilesTool()); selected.append(SearchContentTool()) }
     if wantsGit    { selected.append(GitTool()) }

--- a/Tests/AppleCodeTests/ToolRoutingTests.swift
+++ b/Tests/AppleCodeTests/ToolRoutingTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import apple_code
+
+final class ToolRoutingTests: XCTestCase {
+    private func toolNames(for prompt: String) -> [String] {
+        routeTools(
+            for: prompt,
+            includeAppleTools: false,
+            includeWebTools: false,
+            includeBrowserTools: false
+        ).map(\.name)
+    }
+
+    func testReadOnlyFileIntentDoesNotExposeMutatingTools() {
+        let names = toolNames(for: "read the README file")
+
+        XCTAssertTrue(names.contains(ReadFileTool().name))
+        XCTAssertFalse(names.contains(WriteFileTool().name))
+        XCTAssertFalse(names.contains(EditFileTool().name))
+    }
+
+    func testSearchIntentRemainsReadOnly() {
+        let names = toolNames(for: "search the project for routeTools")
+
+        XCTAssertTrue(names.contains(SearchFilesTool().name))
+        XCTAssertTrue(names.contains(SearchContentTool().name))
+        XCTAssertFalse(names.contains(WriteFileTool().name))
+        XCTAssertFalse(names.contains(EditFileTool().name))
+    }
+
+    func testEditIntentExposesMutatingTools() {
+        let names = toolNames(for: "edit Sources/AppleCode/main.swift to update routeTools")
+
+        XCTAssertTrue(names.contains(ReadFileTool().name))
+        XCTAssertTrue(names.contains(WriteFileTool().name))
+        XCTAssertTrue(names.contains(EditFileTool().name))
+    }
+
+    func testCreateIntentExposesMutatingTools() {
+        let names = toolNames(for: "create a file named notes.txt")
+
+        XCTAssertTrue(names.contains(ReadFileTool().name))
+        XCTAssertTrue(names.contains(WriteFileTool().name))
+        XCTAssertTrue(names.contains(EditFileTool().name))
+    }
+}


### PR DESCRIPTION
Automated Flow Healer proposal for issue #12.

### Verification
- Verifier: `Patch is appropriately scoped and satisfies the issue. In `Sources/AppleCode/main.swift`, file routing now separates read-only file intent from explicit mutating file intent, so read-style prompts only get `ReadFileTool` while edit/create-style prompts stil...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `swift`
- Local full gate: `passed`
